### PR TITLE
Modified chirpstack-mqtt-forwarder.toml for Tektelic

### DIFF
--- a/packaging/vendor/tektelic/kona/files/chirpstack-mqtt-forwarder.toml
+++ b/packaging/vendor/tektelic/kona/files/chirpstack-mqtt-forwarder.toml
@@ -12,9 +12,7 @@
     udp_bind="0.0.0.0:1700"
 
 [mqtt]
-  event_topic="eu868/gateway/{{ gateway_id }}/event/{{ event }}"
-  command_topic="eu868/gateway/{{ gateway_id }}/command/{{ command }}"
-  state_topic="eu868/gateway/{{ gateway_id }}/state/{{ state }}"
+  topic_prefix="eu868"
   server="tcp://127.0.0.1:1883"
   username=""
   password=""


### PR DESCRIPTION
Updated topic prefix into the .toml file and removed deprecated options.