### PR TITLE
Support for AMD64 arch

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,13 @@
+[target.x86_64-unknown-linux-musl]
+  rustflags = [
+    "-C", "target-feature=+crt-static",
+    "-C", "link-arg=-s",
+    "-C", "link-arg=-lc",
+    "-C", "link-arg=-lgcc",
+    "-L", "native=/usr/local/x86_64-linux-musl-target/lib",
+    "-l", "static=stdc++",
+  ]
+  
 [target.aarch64-unknown-linux-musl]
   rustflags = [
     "-C", "target-feature=+crt-static",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,6 @@
+[target.x86_64-unknown-linux-musl]
+dockerfile="cross/Dockerfile.x86_64-unknown-linux-musl"
+
 [target.aarch64-unknown-linux-musl]
 dockerfile="cross/Dockerfile.aarch64-unknown-linux-musl"
 

--- a/cross/Dockerfile.x86_64-unknown-linux-musl
+++ b/cross/Dockerfile.x86_64-unknown-linux-musl
@@ -1,0 +1,28 @@
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:latest
+
+ENV OPENSSL_VERSION=3.1.2
+ENV OPENSSL_TARGET=linux-x86_64
+ENV MUSL_PREFIX=x86_64-linux-musl
+
+RUN apt-get update && \
+    apt-get --assume-yes install \
+    protobuf-compiler \
+    libprotobuf-dev \
+    libssl-dev
+
+RUN echo "Building OpenSSL" && \
+    cd /tmp && \
+    curl -fLO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
+    tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
+    env CC=$MUSL_PREFIX-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/$MUSL_PREFIX-target -DOPENSSL_NO_SECURE_MEMORY $OPENSSL_TARGET && \
+    env C_INCLUDE_PATH=/usr/local/$MUSL_PREFIX/include/ make depend && \
+    env C_INCLUDE_PATH=/usr/local/$MUSL_PREFIX/include/ make && \
+    make install_sw && \
+    rm -r /tmp/*
+
+RUN echo "Copy libstdc++" && \
+    mkdir -p /usr/local/$MUSL_PREFIX-target/lib && \
+    cp /usr/local/$MUSL_PREFIX/lib/libstdc++* /usr/local/$MUSL_PREFIX-target/lib
+
+ENV PKG_CONFIG_PATH=/usr/local/$MUSL_PREFIX-target/lib/pkgconfig
+ENV OPENSSL_DIR=/usr/local/$MUSL_PREFIX-target


### PR DESCRIPTION
Added support to build binary for amd64 arch (x86_64). 
In my usecase this is useful basically for testing (concentratord->mqtt-forwarder->remote chirpstack server) but I thought it could as well be used with the growing offer of x86-based SBCs.