### PR TITLE
Gateway id override

### DIFF
--- a/packaging/vendor/dragino/mips_24kc/files/chirpstack-mqtt-forwarder.toml
+++ b/packaging/vendor/dragino/mips_24kc/files/chirpstack-mqtt-forwarder.toml
@@ -19,3 +19,10 @@
   ca_cert=""
   tls_cert=""
   tls_key=""
+
+[gateway]
+  # Gateway ID.
+  #
+  # Only set this if you would like to override the Gateway ID fetched from the backend.
+  # This will allow the MQTT loop to start prior backend setup.
+  #gateway_id=""

--- a/packaging/vendor/kerlink/klkgw/files/chirpstack-mqtt-forwarder.toml
+++ b/packaging/vendor/kerlink/klkgw/files/chirpstack-mqtt-forwarder.toml
@@ -29,3 +29,10 @@
   ca_cert=""
   tls_cert=""
   tls_key=""
+
+[gateway]
+  # Gateway ID.
+  #
+  # Only set this if you would like to override the Gateway ID fetched from the backend.
+  # This will allow the MQTT loop to start prior backend setup.
+  #gateway_id=""

--- a/packaging/vendor/multitech/conduit/files/ap1/chirpstack-mqtt-forwarder.toml
+++ b/packaging/vendor/multitech/conduit/files/ap1/chirpstack-mqtt-forwarder.toml
@@ -29,3 +29,10 @@
   ca_cert=""
   tls_cert=""
   tls_key=""
+
+[gateway]
+  # Gateway ID.
+  #
+  # Only set this if you would like to override the Gateway ID fetched from the backend.
+  # This will allow the MQTT loop to start prior backend setup.
+  #gateway_id=""

--- a/packaging/vendor/multitech/conduit/files/ap2/chirpstack-mqtt-forwarder.toml
+++ b/packaging/vendor/multitech/conduit/files/ap2/chirpstack-mqtt-forwarder.toml
@@ -29,3 +29,10 @@
   ca_cert=""
   tls_cert=""
   tls_key=""
+
+[gateway]
+  # Gateway ID.
+  #
+  # Only set this if you would like to override the Gateway ID fetched from the backend.
+  # This will allow the MQTT loop to start prior backend setup.
+  #gateway_id=""

--- a/packaging/vendor/multitech/conduit_ap/files/chirpstack-mqtt-forwarder.toml
+++ b/packaging/vendor/multitech/conduit_ap/files/chirpstack-mqtt-forwarder.toml
@@ -29,3 +29,10 @@
   ca_cert=""
   tls_cert=""
   tls_key=""
+
+[gateway]
+  # Gateway ID.
+  #
+  # Only set this if you would like to override the Gateway ID fetched from the backend.
+  # This will allow the MQTT loop to start prior backend setup.
+  #gateway_id=""

--- a/packaging/vendor/multitech/conduit_ap3/files/chirpstack-mqtt-forwarder.toml
+++ b/packaging/vendor/multitech/conduit_ap3/files/chirpstack-mqtt-forwarder.toml
@@ -29,3 +29,10 @@
   ca_cert=""
   tls_cert=""
   tls_key=""
+
+[gateway]
+  # Gateway ID.
+  #
+  # Only set this if you would like to override the Gateway ID fetched from the backend.
+  # This will allow the MQTT loop to start prior backend setup.
+  #gateway_id=""

--- a/packaging/vendor/rak/mipsel_24kc/files/chirpstack-mqtt-forwarder.toml
+++ b/packaging/vendor/rak/mipsel_24kc/files/chirpstack-mqtt-forwarder.toml
@@ -19,3 +19,10 @@
   ca_cert=""
   tls_cert=""
   tls_key=""
+
+[gateway]
+  # Gateway ID.
+  #
+  # Only set this if you would like to override the Gateway ID fetched from the backend.
+  # This will allow the MQTT loop to start prior backend setup.
+  #gateway_id=""

--- a/packaging/vendor/tektelic/kona/files/chirpstack-mqtt-forwarder.toml
+++ b/packaging/vendor/tektelic/kona/files/chirpstack-mqtt-forwarder.toml
@@ -19,3 +19,10 @@
   ca_cert=""
   tls_cert=""
   tls_key=""
+
+[gateway]
+  # Gateway ID.
+  #
+  # Only set this if you would like to override the Gateway ID fetched from the backend.
+  # This will allow the MQTT loop to start prior backend setup.
+  #gateway_id=""

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -67,12 +67,11 @@ pub async fn setup(conf: &Configuration) -> Result<()> {
 }
 
 pub async fn get_gateway_id() -> Result<String> {
-    /*if let Some(b) = BACKEND.get() {
+    if let Some(b) = BACKEND.get() {
         return b.get_gateway_id().await;
     }
 
-    Err(anyhow!("BACKEND is not set"))*/
-    return Ok("008000000002226f".to_string());
+    Err(anyhow!("BACKEND is not set"))
 }
 
 pub async fn send_downlink_frame(pl: &gw::DownlinkFrame) -> Result<()> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -67,11 +67,12 @@ pub async fn setup(conf: &Configuration) -> Result<()> {
 }
 
 pub async fn get_gateway_id() -> Result<String> {
-    if let Some(b) = BACKEND.get() {
+    /*if let Some(b) = BACKEND.get() {
         return b.get_gateway_id().await;
     }
 
-    Err(anyhow!("BACKEND is not set"))
+    Err(anyhow!("BACKEND is not set"))*/
+    return Ok("008000000002226f".to_string());
 }
 
 pub async fn send_downlink_frame(pl: &gw::DownlinkFrame) -> Result<()> {

--- a/src/cmd/configfile.rs
+++ b/src/cmd/configfile.rs
@@ -238,6 +238,16 @@ pub fn run(config: &Configuration) {
 
   # On MQTT connection error.
   on_mqtt_connection_error=[]
+
+
+# Gateway configuration
+[gateway]
+
+  # Gateway ID.
+  #
+  # Only set this if you would like to override the Gateway ID fetched from the backend.
+  # This will allow the MQTT loop to start prior backend setup.
+  #gateway_id="{{ gateway.gateway_id }}"
 "#;
 
     let reg = Handlebars::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub struct Configuration {
     pub metadata: Metadata,
     pub commands: HashMap<String, Vec<String>>,
     pub callbacks: Callbacks,
+    pub gateway: Gateway,
 }
 
 impl Configuration {
@@ -175,4 +176,18 @@ pub struct Metadata {
 pub struct Callbacks {
     pub on_mqtt_connected: Vec<String>,
     pub on_mqtt_connection_error: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(default)]
+pub struct Gateway {
+    pub gateway_id: Option<String>,
+}
+
+impl Default for Gateway {
+    fn default() -> Self {
+        Gateway {
+            gateway_id: None,
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,8 @@ async fn main() {
 
     commands::setup(&config).expect("Setup commands error");
     metadata::setup(&config).expect("Setup metadata error");
-    backend::setup(&config).await.expect("Setup backend error");
     mqtt::setup(&config).await.expect("Setup MQTT client error");
+    backend::setup(&config).await.expect("Setup backend error");
 
     let mut signals = Signals::new([SIGINT, SIGTERM]).unwrap();
     signals.forever().next();

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -45,7 +45,19 @@ pub async fn setup(conf: &Configuration) -> Result<()> {
     };
 
     // get gateway id
-    let gateway_id = get_gateway_id().await?;
+    let gateway_id = if let Some(gateway_id) = &conf.gateway.gateway_id {
+        // use gateway id overriden in config
+        gateway_id.clone()
+    }
+    else {
+        // fetch from backend
+        get_gateway_id().await?
+    };
+
+    info!(
+        "Gateway ID retrieved, gateway_id: {}",
+        gateway_id
+    );
 
     // set client id
     let client_id = if conf.mqtt.client_id.is_empty() {


### PR DESCRIPTION
Actually, mqtt-forwarder fetches the gateway_id from the backend (either concentratord or semtech_udp). In cases where either concentratord / semtech packet forwarder cannot start for various reasons (i.e: hardware problem with the LoRa card), mqtt-forwarder stalls there and no MQTT connection to the remote broker is made (which is fair enough). This means remote commands _cannot_ be executed anymore because it requires an MQTT connection for that.

The proposed feature is to allow the possibility to override the gateway_id in the configuration file. If set by the user, the mqtt client will use the overriden gateway_id in the configuration file rather than waiting for the backend to respond. This allows for remote command execution (which is a nice feature of mqtt-forwarder), even though no concentrator / packet forwarder backend is started.

If gateway_id is not overriden, mqtt-forwarder operates as usual.

Tested successfully on MultiTech MTCAP / MTCDT gateways.