### PR TITLE
Added mqtt reconnect_interval parameter

### DIFF
--- a/src/cmd/configfile.rs
+++ b/src/cmd/configfile.rs
@@ -100,6 +100,12 @@ pub fn run(config: &Configuration) {
   # TLS key file (optional)
   tls_key="{{ mqtt.tls_key }}"
 
+  # Reconnect interval.
+  #
+  # This defines the reconnection interval to the MQTT broker in case of
+  # network issues.
+  reconnect_interval="{{ integration.mqtt.reconnect_interval }}"
+
 
 # Backend configuration.
 [backend]

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,8 @@ pub struct Mqtt {
     pub ca_cert: String,
     pub tls_cert: String,
     pub tls_key: String,
+    #[serde(with = "humantime_serde")]
+    pub reconnect_interval: Duration,
 }
 
 impl Default for Mqtt {
@@ -83,6 +85,7 @@ impl Default for Mqtt {
             ca_cert: "".into(),
             tls_cert: "".into(),
             tls_key: "".into(),
+            reconnect_interval: Duration::from_secs(1),
         }
     }
 }


### PR DESCRIPTION
Allows to custom define the reconnection interval to the MQTT broker in case of network events. Default value is 1 second.