### PR TITLE
Return an error if gateway_id is less bytes than expected

### DIFF
--- a/src/backend/concentratord.rs
+++ b/src/backend/concentratord.rs
@@ -56,6 +56,12 @@ impl Backend {
             return Err(anyhow!("Could not read gateway id"));
         }
         let gateway_id = cmd_sock.recv_bytes(0)?;
+        if gateway_id.len() != 8 {
+            return Err(anyhow!(
+                "Invalid gateway id, expected 8 bytes, received {}",
+                gateway_id.len()
+            ));
+        }
         let gateway_id = hex::encode(gateway_id);
 
         info!("Received gateway id, gateway_id: {}", gateway_id);


### PR DESCRIPTION
`gateway_id` can sometimes be returned as an empty string, this PR makes the concentratord backend setup function return an error if that happens.

Closes #64 