### PR TITLE
Added dynamic commands to metadata

### DIFF
--- a/src/cmd/configfile.rs
+++ b/src/cmd/configfile.rs
@@ -216,6 +216,37 @@ pub fn run(config: &Configuration) {
     {{/each}}
 
 
+  # Dynamic commands (scripts) returning metadata.
+  [metadata.dynamic]
+
+    # Split delimiter.                                            
+    #        
+    # When the output of a command returns multiple lines, ChirpStack MQTT Forwarder
+    # assumes multiple values are returned. In this case it will split by the given delimiter
+    # to obtain the key / value of each row. The key will be prefixed with the name of the
+    # configured command.
+    split_delimiter="="
+
+    # Commands to execute.
+    #
+    # The value of the stdout will be used as the key value (string).
+    # In case the command failed, it is ignored. In case delimiter is not found in stdout  In case the same key is defined
+    # both as static and dynamic, the dynamic value has priority (as long as the) command does not fail.                                   
+    # If delimieter is not found in the stdout, the value is ignored and Chirpstack MQTT Forwarder will write a WARN log.
+
+    [metadata.dynamic.commands]
+      # Example:
+      #temperature="/opt/gateway-temperature/gateway-temperature.sh"
+      {{#each metadata.dynamic.commands}}
+      {{ @key }}=[
+        {{#each this}}
+        "{{ this }}",
+        {{/each}}
+      ]
+      {{/each}}
+
+
+
 # Executable commands.
 [commands]
 

--- a/src/cmd/configfile.rs
+++ b/src/cmd/configfile.rs
@@ -205,6 +205,21 @@ pub fn run(config: &Configuration) {
   # Commands returning metadata.
   [metadata.commands]
 
+    # Split delimiter
+    #
+    # When the output of a command returns multiple lines, ChirpStack MQTT Forwarder
+    # assumes multiple values are returned. In this case, it will split by the given delimiter
+    # to optain the key / value of each row. The key will be prefixed with the name of the 
+    # configured command.
+    # When the output of a command is a single line, ChirpStack MQTT Forwarder checks, if
+    # the line has the delimiter in it. if so, it splits by the delimiter and obtains key / value 
+    # The key will be prefixed with the name of the configured key. if the delimiter is not found, 
+    # Chirpstack MQTT Forwarder assumes, that the output is only a value and will return the name of the command
+    # as key and the output of the command as value.
+    # Default value of split_delimiter is =
+
+    # split_delimiter="="
+
     # Example:
     # datetime=["date", "-R"]
     {{#each metadata.commands}}
@@ -214,37 +229,6 @@ pub fn run(config: &Configuration) {
       {{/each}}
     ]
     {{/each}}
-
-
-  # Dynamic commands (scripts) returning metadata.
-  [metadata.dynamic]
-
-    # Split delimiter.                                            
-    #        
-    # When the output of a command returns multiple lines, ChirpStack MQTT Forwarder
-    # assumes multiple values are returned. In this case it will split by the given delimiter
-    # to obtain the key / value of each row. The key will be prefixed with the name of the
-    # configured command.
-    split_delimiter="="
-
-    # Commands to execute.
-    #
-    # The value of the stdout will be used as the key value (string).
-    # In case the command failed, it is ignored. In case delimiter is not found in stdout  In case the same key is defined
-    # both as static and dynamic, the dynamic value has priority (as long as the) command does not fail.                                   
-    # If delimieter is not found in the stdout, the value is ignored and Chirpstack MQTT Forwarder will write a WARN log.
-
-    [metadata.dynamic.commands]
-      # Example:
-      #temperature="/opt/gateway-temperature/gateway-temperature.sh"
-      {{#each metadata.dynamic.commands}}
-      {{ @key }}=[
-        {{#each this}}
-        "{{ this }}",
-        {{/each}}
-      ]
-      {{/each}}
-
 
 
 # Executable commands.

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,14 +171,7 @@ impl Default for SemtechUdp {
 pub struct Metadata {
     pub r#static: HashMap<String, String>,
     pub commands: HashMap<String, Vec<String>>,
-    pub dynamic: DynamicMetadata,
-}
-
-#[derive(Serialize, Deserialize, Default)]
-#[serde(default)]
-pub struct DynamicMetadata {
-    pub split_delimiter: String, 
-    pub commands: HashMap<String, String>,
+    pub split_delimiter: String,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,12 +166,22 @@ impl Default for SemtechUdp {
     }
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize)]
 #[serde(default)]
 pub struct Metadata {
     pub r#static: HashMap<String, String>,
     pub commands: HashMap<String, Vec<String>>,
     pub split_delimiter: String,
+}
+
+impl Default for Metadata {
+    fn default() -> Self {
+        Metadata {
+            r#static: HashMap::default(),
+            commands: HashMap::default(),
+            split_delimiter: "=".to_string(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,6 +171,14 @@ impl Default for SemtechUdp {
 pub struct Metadata {
     pub r#static: HashMap<String, String>,
     pub commands: HashMap<String, Vec<String>>,
+    pub dynamic: DynamicMetadata,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct DynamicMetadata {
+    pub split_delimiter: String, 
+    pub commands: HashMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
 use anyhow::Result;
-use log::error;
+use log::{error, warn};
 use tokio::process::Command;
 
 use crate::config::Configuration;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -11,12 +11,13 @@ static METADATA: LazyLock<RwLock<HashMap<String, String>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 static COMMANDS: LazyLock<RwLock<HashMap<String, Vec<String>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
-static SPLIT_DELIMITER: LazyLock<RwLock<String>> = LazyLock::new(|| RwLock::new("=".to_string()));
+static SPLIT_DELIMITER: LazyLock<RwLock<String>> = LazyLock::new(|| RwLock::new("".into()));
 
 pub fn setup(conf: &Configuration) -> Result<()> {
     let mut metadata_w = METADATA.write().unwrap();
     let mut commands_w = COMMANDS.write().unwrap();
-    let mut split_delimiter_w = SPLIT_DELIMITER.write().unwrap(); // Access the delimiter
+    let mut split_delimiter_w = SPLIT_DELIMITER.write().unwrap();
+
     metadata_w.clone_from(&conf.metadata.r#static);
     commands_w.clone_from(&conf.metadata.commands);
     *split_delimiter_w = conf.metadata.split_delimiter.clone();

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -11,12 +11,20 @@ static METADATA: LazyLock<RwLock<HashMap<String, String>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 static COMMANDS: LazyLock<RwLock<HashMap<String, Vec<String>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
+static DYNAMIC_COMMANDS: LazyLock<RwLock<HashMap<String, String>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+static SPLIT_DELIMITER: LazyLock<RwLock<String>> =
+    LazyLock::new(|| RwLock::new("=".to_string()));
 
 pub fn setup(conf: &Configuration) -> Result<()> {
     let mut metadata_w = METADATA.write().unwrap();
     let mut commands_w = COMMANDS.write().unwrap();
+    let mut dynamic_commands_w = DYNAMIC_COMMANDS.write().unwrap();
+    let mut split_delimiter_w = SPLIT_DELIMITER.write().unwrap();
     metadata_w.clone_from(&conf.metadata.r#static);
     commands_w.clone_from(&conf.metadata.commands);
+    dynamic_commands_w.clone_from(&conf.metadata.dynamic.commands);
+    *split_delimiter_w = conf.metadata.dynamic.split_delimiter.clone();
 
     Ok(())
 }
@@ -29,6 +37,8 @@ pub async fn get() -> Result<HashMap<String, String>> {
     );
 
     let commands = COMMANDS.read().unwrap().clone();
+    let dynamic_commands = DYNAMIC_COMMANDS.read().unwrap().clone();
+    let split_delimiter = SPLIT_DELIMITER.read().unwrap().clone();
 
     for (k, v) in commands {
         if v.is_empty() {
@@ -49,6 +59,29 @@ pub async fn get() -> Result<HashMap<String, String>> {
 
         let out = String::from_utf8(out.stdout)?;
         metadata.insert(k.to_string(), out.trim().to_string());
+    }
+
+    for (k, v) in dynamic_commands {
+        let mut cmd = Command::new(&v);
+        let out = cmd.output().await?;
+
+        if !out.status.success() {
+            error!("Dynamic metadata command execution failed, command: {}", v);
+            continue;
+        }
+
+        let out = String::from_utf8(out.stdout)?;
+        for line in out.lines() {
+            if let Some((key, value)) = line.split_once(&split_delimiter) {
+                let prefixed_key = format!("{}_{}", k, key.trim());
+                metadata.insert(prefixed_key, value.trim().to_string());
+            } else {
+                warn!(
+                    "Dynamic metadata command output invalid (missing delimiter '{}'): {}",
+                    split_delimiter, line
+                );
+            }
+        }
     }
 
     Ok(metadata)

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -11,20 +11,16 @@ static METADATA: LazyLock<RwLock<HashMap<String, String>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 static COMMANDS: LazyLock<RwLock<HashMap<String, Vec<String>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
-static DYNAMIC_COMMANDS: LazyLock<RwLock<HashMap<String, String>>> =
-    LazyLock::new(|| RwLock::new(HashMap::new()));
 static SPLIT_DELIMITER: LazyLock<RwLock<String>> =
-    LazyLock::new(|| RwLock::new("=".to_string()));
+    LazyLock::new(|| RwLock::new("=".to_string())); 
 
 pub fn setup(conf: &Configuration) -> Result<()> {
     let mut metadata_w = METADATA.write().unwrap();
     let mut commands_w = COMMANDS.write().unwrap();
-    let mut dynamic_commands_w = DYNAMIC_COMMANDS.write().unwrap();
-    let mut split_delimiter_w = SPLIT_DELIMITER.write().unwrap();
+    let mut split_delimiter_w = SPLIT_DELIMITER.write().unwrap(); // Access the delimiter
     metadata_w.clone_from(&conf.metadata.r#static);
     commands_w.clone_from(&conf.metadata.commands);
-    dynamic_commands_w.clone_from(&conf.metadata.dynamic.commands);
-    *split_delimiter_w = conf.metadata.dynamic.split_delimiter.clone();
+    *split_delimiter_w = conf.metadata.split_delimiter.clone();
 
     Ok(())
 }
@@ -37,7 +33,6 @@ pub async fn get() -> Result<HashMap<String, String>> {
     );
 
     let commands = COMMANDS.read().unwrap().clone();
-    let dynamic_commands = DYNAMIC_COMMANDS.read().unwrap().clone();
     let split_delimiter = SPLIT_DELIMITER.read().unwrap().clone();
 
     for (k, v) in commands {
@@ -58,28 +53,23 @@ pub async fn get() -> Result<HashMap<String, String>> {
         }
 
         let out = String::from_utf8(out.stdout)?;
-        metadata.insert(k.to_string(), out.trim().to_string());
-    }
+        let lines: Vec<&str> = out.lines().collect();
 
-    for (k, v) in dynamic_commands {
-        let mut cmd = Command::new(&v);
-        let out = cmd.output().await?;
-
-        if !out.status.success() {
-            error!("Dynamic metadata command execution failed, command: {}", v);
-            continue;
-        }
-
-        let out = String::from_utf8(out.stdout)?;
-        for line in out.lines() {
+        if lines.len() > 1 {
+             for line in lines {
+                 if let Some((key, value)) = line.split_once(&split_delimiter) {
+                     let prefixed_key = format!("{}_{}", k, key.trim());
+                     metadata.insert(prefixed_key, value.trim().to_string());
+                 } else {
+                     warn!("Multi-line command output, but no delimiter {} detected: {}", split_delimiter, line);
+                 }
+             }
+        } else if let Some(line) = lines.first() {
             if let Some((key, value)) = line.split_once(&split_delimiter) {
                 let prefixed_key = format!("{}_{}", k, key.trim());
                 metadata.insert(prefixed_key, value.trim().to_string());
             } else {
-                warn!(
-                    "Dynamic metadata command output invalid (missing delimiter '{}'): {}",
-                    split_delimiter, line
-                );
+                metadata.insert(k.to_string(), line.trim().to_string());
             }
         }
     }

--- a/tests/concentratord_test.rs
+++ b/tests/concentratord_test.rs
@@ -38,8 +38,20 @@ async fn end_to_end() {
         (
             "multiline".to_string(),
             vec![
-                "echo".to_string(), "key1=value1\nkey2=value2\nkey3=value3".to_string(),
-             ],
+                "echo".to_string(),
+                "key1=value1\nkey2=value2\nkey3=value3\n".to_string(),
+            ],
+        ),
+        (
+            "multiline_error".to_string(),
+            vec![
+                "echo".to_string(),
+                "key1=value1\nkey2-value2\nkey3=value3\n".to_string(),
+            ],
+        ),
+        (
+            "single_kv".to_string(),
+            vec!["echo".to_string(), "key1=value1".to_string()],
         ),
     ]);
 
@@ -193,6 +205,9 @@ async fn end_to_end() {
                 ("multiline_key1".to_string(), "value1".to_string()),
                 ("multiline_key2".to_string(), "value2".to_string()),
                 ("multiline_key3".to_string(), "value3".to_string()),
+                ("single_kv_key1".to_string(), "value1".to_string()),
+                ("multiline_error_key1".to_string(), "value1".to_string()),
+                ("multiline_error_key3".to_string(), "value3".to_string()),
             ]
             .iter()
             .cloned()

--- a/tests/concentratord_test.rs
+++ b/tests/concentratord_test.rs
@@ -30,10 +30,18 @@ async fn end_to_end() {
     c.metadata
         .r#static
         .insert("foo".to_string(), "bar".to_string());
-    c.metadata.commands.insert(
-        "hello".to_string(),
-        vec!["echo".to_string(), "hello world".to_string()],
-    );
+    c.metadata.commands.extend([
+        (
+            "hello".to_string(),
+            vec!["echo".to_string(), "hello world".to_string()],
+        ),
+        (
+            "multiline".to_string(),
+            vec![
+                "echo".to_string(), "key1=value1\nkey2=value2\nkey3=value3".to_string(),
+             ],
+        ),
+    ]);
 
     // MQTT
     let mut mqtt_opts = MqttOptions::parse_url(format!(
@@ -182,6 +190,9 @@ async fn end_to_end() {
                 ),
                 ("foo".to_string(), "bar".to_string()),
                 ("hello".to_string(), "hello world".to_string()),
+                ("multiline_key1".to_string(), "value1".to_string()),
+                ("multiline_key2".to_string(), "value2".to_string()),
+                ("multiline_key3".to_string(), "value3".to_string()),
             ]
             .iter()
             .cloned()

--- a/tests/semtech_udp_test.rs
+++ b/tests/semtech_udp_test.rs
@@ -33,10 +33,19 @@ async fn end_to_end() {
     c.metadata
         .r#static
         .insert("foo".to_string(), "bar".to_string());
-    c.metadata.commands.insert(
-        "hello".to_string(),
-        vec!["echo".to_string(), "hello world".to_string()],
-    );
+    c.metadata.commands.extend([
+        (
+            "hello".to_string(),
+            vec!["echo".to_string(), "hello world".to_string()],
+        ),
+        (
+            "multiline".to_string(),
+            vec![
+                "echo".to_string(), "key1=value1\nkey2=value2\nkey3=value3".to_string(),
+             ],
+        ),
+    ]);
+
 
     // UDP
     let socket = UdpSocket::bind("0.0.0.0:0").await.unwrap();
@@ -330,6 +339,9 @@ async fn end_to_end() {
                 ),
                 ("foo".to_string(), "bar".to_string()),
                 ("hello".to_string(), "hello world".to_string()),
+                ("multiline_key1".to_string(), "value1".to_string()),
+                ("multiline_key2".to_string(), "value2".to_string()),
+                ("multiline_key3".to_string(), "value3".to_string()),
             ]
             .iter()
             .cloned()


### PR DESCRIPTION
Hi Orne,

A few days ago, I posted on the forum about dynamic metadata for the Chirpstack MQTT forwarder.
You can find the discussion here: [Chirpstack Forum](https://support.chirpstack.io/questions/10010000000000793/10020000000000796).

This pull request addresses the topic by allowing a script to be added to the configuration file. The script's stdout will be parsed into metadata, with the prefix defined in the configuration file key.

I’m not an experienced developer, so I would greatly appreciate it if you could review the code and provide your feedback.

I’ve tested the compiled code on my Multitech gateways, and it successfully sends dynamic metadata.

Thank you in advance for your time and help!
